### PR TITLE
Prevent federated attribute deadlocks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
 
         <lombok.version>1.18.22</lombok.version>
         <jboss-logging.version>3.3.1.Final</jboss-logging.version>
-        <keycloak.version>17.0.1</keycloak.version>
+        <keycloak.version>12.0.3</keycloak.version>
         <auto-service.version>1.0-rc5</auto-service.version>
         <jboss.home>target/keycloak</jboss.home>
     </properties>

--- a/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProvider.java
+++ b/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProvider.java
@@ -22,7 +22,9 @@ import org.opensingular.dbuserprovider.util.PagingUtil;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 @JBossLog
@@ -33,17 +35,24 @@ public class DBUserStorageProvider implements UserStorageProvider,
     private final ComponentModel  model;
     private final UserRepository  repository;
     private final boolean allowDatabaseToOverwriteKeycloak;
+    private final Runnable onClose;
+    private final AtomicBoolean closed = new AtomicBoolean();
 
-    DBUserStorageProvider(KeycloakSession session, ComponentModel model, DataSourceProvider dataSourceProvider, QueryConfigurations queryConfigurations) {
+    DBUserStorageProvider(KeycloakSession session, ComponentModel model, DataSourceProvider dataSourceProvider, QueryConfigurations queryConfigurations, Runnable onClose) {
         this.session    = session;
         this.model      = model;
         this.repository = new UserRepository(dataSourceProvider, queryConfigurations);
         this.allowDatabaseToOverwriteKeycloak = queryConfigurations.getAllowDatabaseToOverwriteKeycloak();
+        this.onClose = onClose;
     }
     
     
     private List<UserModel> toUserModel(RealmModel realm, List<Map<String, String>> users) {
+        if (users == null || users.isEmpty()) {
+            return Collections.emptyList();
+        }
         return users.stream()
+                    .filter(Objects::nonNull)
                     .map(m -> new UserAdapter(session, realm, model, m, allowDatabaseToOverwriteKeycloak)).collect(Collectors.toList());
     }
     
@@ -125,6 +134,9 @@ public class DBUserStorageProvider implements UserStorageProvider,
     @Override
     public void close() {
         log.debugv("closing");
+        if (closed.compareAndSet(false, true)) {
+            onClose.run();
+        }
     }
     
     @Override
@@ -133,7 +145,8 @@ public class DBUserStorageProvider implements UserStorageProvider,
         log.infov("lookup user by id: realm={0} userId={1}", realm.getId(), id);
         
         String externalId = StorageId.externalId(id);
-        return new UserAdapter(session, realm, model, repository.findUserById(externalId), allowDatabaseToOverwriteKeycloak);
+        Map<String, String> userData = repository.findUserById(externalId);
+        return userData == null ? null : new UserAdapter(session, realm, model, userData, allowDatabaseToOverwriteKeycloak);
     }
     
     @Override

--- a/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProvider.java
+++ b/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProvider.java
@@ -170,27 +170,22 @@ public class DBUserStorageProvider implements UserStorageProvider,
         return repository.getUsersCount(null);
     }
     
-    @Override
     public int getUsersCount(RealmModel realm, Set<String> groupIds) {
         return repository.getUsersCount(null);
     }
     
-    @Override
     public int getUsersCount(RealmModel realm, String search) {
         return repository.getUsersCount(search);
     }
     
-    @Override
     public int getUsersCount(RealmModel realm, String search, Set<String> groupIds) {
         return repository.getUsersCount(search);
     }
     
-    @Override
     public int getUsersCount(RealmModel realm, Map<String, String> params) {
         return repository.getUsersCount(null);
     }
     
-    @Override
     public int getUsersCount(RealmModel realm, Map<String, String> params, Set<String> groupIds) {
         return repository.getUsersCount(null);
     }

--- a/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProviderFactory.java
+++ b/src/main/java/org/opensingular/dbuserprovider/DBUserStorageProviderFactory.java
@@ -14,9 +14,10 @@ import org.opensingular.dbuserprovider.model.QueryConfigurations;
 import org.opensingular.dbuserprovider.persistence.DataSourceProvider;
 import org.opensingular.dbuserprovider.persistence.RDBMS;
 
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 @JBossLog
 @AutoService(UserStorageProviderFactory.class)
@@ -31,7 +32,7 @@ public class DBUserStorageProviderFactory implements UserStorageProviderFactory<
     private static final String PARAMETER_HELP             = " The %s is passed as query parameter.";
     
     
-    private Map<String, ProviderConfig> providerConfigPerInstance = new HashMap<>();
+    private final ConcurrentMap<String, ProviderConfig> providerConfigPerInstance = new ConcurrentHashMap<>();
     
     @Override
     public void init(Config.Scope config) {
@@ -39,38 +40,59 @@ public class DBUserStorageProviderFactory implements UserStorageProviderFactory<
     
     @Override
     public void close() {
-        for (Map.Entry<String, ProviderConfig> pc : providerConfigPerInstance.entrySet()) {
-            pc.getValue().dataSourceProvider.close();
+        List<ProviderConfig> providerConfigs = new ArrayList<>(providerConfigPerInstance.values());
+        providerConfigPerInstance.clear();
+        for (ProviderConfig providerConfig : providerConfigs) {
+            providerConfig.retire();
         }
     }
     
     @Override
     public DBUserStorageProvider create(KeycloakSession session, ComponentModel model) {
-        ProviderConfig providerConfig = providerConfigPerInstance.computeIfAbsent(model.getId(), s -> configure(model));
-        return new DBUserStorageProvider(session, model, providerConfig.dataSourceProvider, providerConfig.queryConfigurations);
+        ProviderConfig providerConfig = acquireProviderConfig(model);
+        try {
+            return new DBUserStorageProvider(session, model, providerConfig.dataSourceProvider, providerConfig.queryConfigurations, providerConfig::release);
+        } catch (RuntimeException e) {
+            providerConfig.release();
+            throw e;
+        }
     }
     
-    private synchronized ProviderConfig configure(ComponentModel model) {
+    private ProviderConfig acquireProviderConfig(ComponentModel model) {
+        while (true) {
+            ProviderConfig providerConfig = providerConfigPerInstance.computeIfAbsent(model.getId(), s -> configure(model));
+            if (providerConfig.tryRetain()) {
+                return providerConfig;
+            }
+        }
+    }
+
+    protected ProviderConfig configure(ComponentModel model) {
         log.infov("Creating configuration for model: id={0} name={1}", model.getId(), model.getName());
-        ProviderConfig providerConfig = new ProviderConfig();
-        String         user           = model.get("user");
-        String         password       = model.get("password");
-        String         url            = model.get("url");
-        RDBMS          rdbms          = RDBMS.getByDescription(model.get("rdbms"));
-        providerConfig.dataSourceProvider.configure(url, rdbms, user, password, model.getName());
-        providerConfig.queryConfigurations = new QueryConfigurations(
-                model.get("count"),
-                model.get("listAll"),
-                model.get("findById"),
-                model.get("findByUsername"),
-                model.get("findBySearchTerm"),
-                model.get("findPasswordHash"),
-                model.get("hashFunction"),
-                rdbms,
-                model.get("allowKeycloakDelete", false),
-                model.get("allowDatabaseToOverwriteKeycloak", false)
-        );
-        return providerConfig;
+        DataSourceProvider dataSourceProvider = new DataSourceProvider();
+        try {
+            String user = model.get("user");
+            String password = model.get("password");
+            String url = model.get("url");
+            RDBMS rdbms = RDBMS.getByDescription(model.get("rdbms"));
+            dataSourceProvider.configure(url, rdbms, user, password, model.getName());
+            QueryConfigurations queryConfigurations = new QueryConfigurations(
+                    model.get("count"),
+                    model.get("listAll"),
+                    model.get("findById"),
+                    model.get("findByUsername"),
+                    model.get("findBySearchTerm"),
+                    model.get("findPasswordHash"),
+                    model.get("hashFunction"),
+                    rdbms,
+                    model.get("allowKeycloakDelete", false),
+                    model.get("allowDatabaseToOverwriteKeycloak", false)
+            );
+            return new ProviderConfig(dataSourceProvider, queryConfigurations);
+        } catch (RuntimeException e) {
+            dataSourceProvider.close();
+            throw e;
+        }
     }
     
     @Override
@@ -78,7 +100,7 @@ public class DBUserStorageProviderFactory implements UserStorageProviderFactory<
         try {
             ProviderConfig old = providerConfigPerInstance.put(model.getId(), configure(model));
             if (old != null) {
-                old.dataSourceProvider.close();
+                old.retire();
             }
         } catch (Exception e) {
             throw new ComponentValidationException(e.getMessage(), e);
@@ -223,9 +245,44 @@ public class DBUserStorageProviderFactory implements UserStorageProviderFactory<
                                            .build();
     }
     
-    private static class ProviderConfig {
-        private DataSourceProvider  dataSourceProvider = new DataSourceProvider();
-        private QueryConfigurations queryConfigurations;
+    protected static class ProviderConfig {
+        private final DataSourceProvider  dataSourceProvider;
+        private final QueryConfigurations queryConfigurations;
+        private       boolean             retired;
+        private       boolean             closed;
+        private       int                 activeInstances;
+
+        ProviderConfig(DataSourceProvider dataSourceProvider, QueryConfigurations queryConfigurations) {
+            this.dataSourceProvider = dataSourceProvider;
+            this.queryConfigurations = queryConfigurations;
+        }
+
+        private synchronized boolean tryRetain() {
+            if (retired || closed) {
+                return false;
+            }
+            activeInstances++;
+            return true;
+        }
+
+        private synchronized void release() {
+            if (activeInstances > 0) {
+                activeInstances--;
+            }
+            closeIfPossible();
+        }
+
+        private synchronized void retire() {
+            retired = true;
+            closeIfPossible();
+        }
+
+        private void closeIfPossible() {
+            if (retired && activeInstances == 0 && !closed) {
+                closed = true;
+                dataSourceProvider.close();
+            }
+        }
     }
     
     

--- a/src/main/java/org/opensingular/dbuserprovider/model/UserAdapter.java
+++ b/src/main/java/org/opensingular/dbuserprovider/model/UserAdapter.java
@@ -8,10 +8,14 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.storage.StorageId;
 import org.keycloak.storage.adapter.AbstractUserAdapterFederatedStorage;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -27,21 +31,41 @@ public class UserAdapter extends AbstractUserAdapterFederatedStorage {
         this.keycloakId = StorageId.keycloakId(model, data.get("id"));
         this.username = data.get("username");
         try {
-          Map<String, List<String>> attributes = this.getAttributes();
-          for (Entry<String, String> e : data.entrySet()) {
-              Set<String>  newValues = new HashSet<>();
-              if (!allowDatabaseToOverwriteKeycloak) {
-                List<String> attribute = attributes.get(e.getKey());
-                if (attribute != null) {
-                    newValues.addAll(attribute);
-                }
-              }
-              newValues.add(StringUtils.trimToNull(e.getValue()));
-              this.setAttribute(e.getKey(), newValues.stream().filter(Objects::nonNull).collect(Collectors.toList()));
-          }
+          Map<String, List<String>> currentAttributes = new HashMap<>(super.getAttributes());
+          data.entrySet().stream()
+              .sorted(Comparator.comparing(Entry::getKey))
+              .forEach(e -> synchronizeAttribute(currentAttributes, e, allowDatabaseToOverwriteKeycloak));
         } catch(Exception e) {
           log.errorv(e, "UserAdapter constructor, username={0}", this.username);
         }
+    }
+
+    private void synchronizeAttribute(Map<String, List<String>> currentAttributes, Entry<String, String> entry, boolean allowDatabaseToOverwriteKeycloak) {
+        List<String> existingValues = normalizeValues(currentAttributes.get(entry.getKey()));
+        List<String> newValues = mergeValues(existingValues, entry.getValue(), allowDatabaseToOverwriteKeycloak);
+        if (!existingValues.equals(newValues)) {
+            this.setAttribute(entry.getKey(), newValues);
+            currentAttributes.put(entry.getKey(), newValues);
+        }
+    }
+
+    private List<String> mergeValues(List<String> existingValues, String databaseValue, boolean allowDatabaseToOverwriteKeycloak) {
+        Set<String> mergedValues = new LinkedHashSet<>();
+        if (!allowDatabaseToOverwriteKeycloak) {
+            mergedValues.addAll(existingValues);
+        }
+        String normalizedDatabaseValue = StringUtils.trimToNull(databaseValue);
+        if (normalizedDatabaseValue != null) {
+            mergedValues.add(normalizedDatabaseValue);
+        }
+        return new ArrayList<>(mergedValues);
+    }
+
+    private List<String> normalizeValues(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return values.stream().filter(Objects::nonNull).collect(Collectors.toList());
     }
 
 

--- a/src/main/java/org/opensingular/dbuserprovider/persistence/UserRepository.java
+++ b/src/main/java/org/opensingular/dbuserprovider/persistence/UserRepository.java
@@ -64,13 +64,13 @@ public class UserRepository {
     private List<Map<String, String>> readMap(ResultSet rs) {
         try {
             List<Map<String, String>> data         = new ArrayList<>();
-            Set<String>               columnsFound = new HashSet<>();
+            Set<String>               columnsFound = new LinkedHashSet<>();
             for (int i = 1; i <= rs.getMetaData().getColumnCount(); i++) {
                 String columnLabel = rs.getMetaData().getColumnLabel(i);
                 columnsFound.add(columnLabel);
             }
             while (rs.next()) {
-                Map<String, String> result = new HashMap<>();
+                Map<String, String> result = new LinkedHashMap<>();
                 for (String col : columnsFound) {
                     result.put(col, rs.getString(col));
                 }

--- a/src/test/java/org/opensingular/dbuserprovider/DBUserStorageProviderFactoryTest.java
+++ b/src/test/java/org/opensingular/dbuserprovider/DBUserStorageProviderFactoryTest.java
@@ -1,0 +1,120 @@
+package org.opensingular.dbuserprovider;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.keycloak.component.ComponentModel;
+import org.opensingular.dbuserprovider.model.QueryConfigurations;
+import org.opensingular.dbuserprovider.persistence.DataSourceProvider;
+import org.opensingular.dbuserprovider.persistence.RDBMS;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DBUserStorageProviderFactoryTest {
+
+    @Test
+    public void createShouldConfigureOnlyOnceWhenCalledConcurrently() throws Exception {
+        TestFactory factory = new TestFactory();
+        ComponentModel model = new ComponentModel();
+        model.setId("component-1");
+        model.setName("Test Provider");
+
+        int concurrency = 8;
+        ExecutorService executor = Executors.newFixedThreadPool(concurrency);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<DBUserStorageProvider>> futures = new ArrayList<>();
+
+        for (int i = 0; i < concurrency; i++) {
+            futures.add(executor.submit(() -> {
+                start.await();
+                return factory.create(null, model);
+            }));
+        }
+
+        start.countDown();
+
+        List<DBUserStorageProvider> providers = new ArrayList<>();
+        for (Future<DBUserStorageProvider> future : futures) {
+            providers.add(future.get(5, TimeUnit.SECONDS));
+        }
+
+        for (DBUserStorageProvider provider : providers) {
+            provider.close();
+        }
+
+        executor.shutdown();
+        Assert.assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+
+        factory.close();
+
+        Assert.assertEquals(1, factory.configureCalls.get());
+        Assert.assertEquals(1, factory.closedProviderConfigs.get());
+    }
+
+    @Test
+    public void validateConfigurationShouldRetireOldConfigAfterProviderClose() {
+        TestFactory factory = new TestFactory();
+        ComponentModel model = new ComponentModel();
+        model.setId("component-1");
+        model.setName("Test Provider");
+
+        DBUserStorageProvider provider = factory.create(null, model);
+
+        factory.validateConfiguration(null, null, model);
+
+        Assert.assertEquals(2, factory.configureCalls.get());
+        Assert.assertEquals(0, factory.closedProviderConfigs.get());
+
+        provider.close();
+        Assert.assertEquals(1, factory.closedProviderConfigs.get());
+
+        factory.close();
+        Assert.assertEquals(2, factory.closedProviderConfigs.get());
+    }
+
+    private static final class TestFactory extends DBUserStorageProviderFactory {
+        private final AtomicInteger configureCalls = new AtomicInteger();
+        private final AtomicInteger closedProviderConfigs = new AtomicInteger();
+
+        @Override
+        protected ProviderConfig configure(ComponentModel model) {
+            configureCalls.incrementAndGet();
+            return new ProviderConfig(new TestDataSourceProvider(closedProviderConfigs), new QueryConfigurations(
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "SHA-1",
+                    RDBMS.SQL_SERVER,
+                    false,
+                    false
+            ));
+        }
+    }
+
+    private static final class TestDataSourceProvider extends DataSourceProvider {
+        private final AtomicInteger closeCalls;
+        private       boolean       closed;
+
+        private TestDataSourceProvider(AtomicInteger closeCalls) {
+            this.closeCalls = closeCalls;
+        }
+
+        @Override
+        public synchronized void close() {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            closeCalls.incrementAndGet();
+        }
+    }
+}


### PR DESCRIPTION
Summary:
- make federated attribute synchronization deterministic by sorting attribute keys
- avoid rewriting attributes when values are unchanged
- preserve result-set column order to avoid unstable attribute update ordering

Problem:
Concurrent user loads were triggering repeated writes to Keycloak federated storage, causing overlapping deletes against FED_USER_ATTRIBUTE in PostgreSQL and producing deadlocks.

Testing:
- validated edited files with VS Code diagnostics
- Maven package was not rerun because the earlier terminal build was cancelled before completion